### PR TITLE
remove require and use es6 import instead

### DIFF
--- a/packages/matrix-crdt/src/util/olmlib.ts
+++ b/packages/matrix-crdt/src/util/olmlib.ts
@@ -24,8 +24,7 @@ limitations under the License.
 
 //  import {logger} from '../logger';
 //  import * as utils from "../utils";
-// import anotherjson from "another-json";
-const anotherjson = require("another-json");
+import * as anotherjson from "another-json";
 //  /**
 //   * matrix algorithm tag for olm
 //   */


### PR DESCRIPTION
Hi, thank you for making this library! Please consider this PR to make it easier to use it in environments that do not support `require` (such as Vite).

Thank you again for building this – I'm working on a little project on top of this and getting to use Matrix as a backend and user provider is wonderful!
